### PR TITLE
Add new feature for users to share multiple customized folders

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -101,6 +101,7 @@ while true; do
     if [[ -z "$custom_path" ]]; then
         custom_path="/home/"
         share_name="home"
+        add_smb_share "$custom_path" "$share_name"
         echo "No path entered. Defaulting to share the entire /home directory."
     elif [[ -d "$custom_path" ]]; then
         share_name=$(basename "$custom_path")

--- a/script.sh
+++ b/script.sh
@@ -73,13 +73,20 @@ sudo pacman -Sy --noconfirm samba
 # Ask user for share configuration
 echo "Enter the path of the directory you want to share, or press ENTER to share the entire /home directory:"
 read -p "Path: " custom_path
+
+# Check if the path is a directory and exists
 if [[ -z "$custom_path" ]]; then
   custom_path="/home/"
   share_name="home"
   echo "No path entered. Defaulting to share the entire /home directory."
 else
-  share_name=$(basename "$custom_path")
-  echo "You have chosen to share: $custom_path"
+  if [[ -d "$custom_path" ]]; then
+    share_name=$(basename "$custom_path")
+    echo "You have chosen to share: $custom_path"
+  else
+    echo "The path '$custom_path' does not exist or is not a directory. Please check the path and try again."
+    exit 1
+  fi
 fi
 
 # Confirm sharing setup

--- a/script.sh
+++ b/script.sh
@@ -71,23 +71,24 @@ echo "Installing samba..."
 sudo pacman -Sy --noconfirm samba
 
 # Ask user for share configuration
-echo "Enter the path of the directory you want to share, or press ENTER to share the entire /home directory:"
-read -p "Path: " custom_path
+while true; do
+    echo "Enter the path of the directory you want to share, or press ENTER to share the entire /home directory:"
+    read -p "Path: " custom_path
 
-# Check if the path is a directory and exists
-if [[ -z "$custom_path" ]]; then
-  custom_path="/home/"
-  share_name="home"
-  echo "No path entered. Defaulting to share the entire /home directory."
-else
-  if [[ -d "$custom_path" ]]; then
-    share_name=$(basename "$custom_path")
-    echo "You have chosen to share: $custom_path"
-  else
-    echo "The path '$custom_path' does not exist or is not a directory. Please check the path and try again."
-    exit 1
-  fi
-fi
+    # Check if the path is a directory and exists
+    if [[ -z "$custom_path" ]]; then
+        custom_path="/home/"
+        share_name="home"
+        echo "No path entered. Defaulting to share the entire /home directory."
+        break
+    elif [[ -d "$custom_path" ]]; then
+        share_name=$(basename "$custom_path")
+        echo "You have chosen to share: $custom_path"
+        break
+    else
+        echo "The path '$custom_path' does not exist or is not a directory. Please check the path and try again."
+    fi
+done
 
 # Confirm sharing setup
 while true; do

--- a/script.sh
+++ b/script.sh
@@ -102,7 +102,6 @@ while true; do
         custom_path="/home/"
         share_name="home"
         echo "No path entered. Defaulting to share the entire /home directory."
-        break
     elif [[ -d "$custom_path" ]]; then
         share_name=$(basename "$custom_path")
         # create new share

--- a/script.sh
+++ b/script.sh
@@ -90,6 +90,16 @@ directory mask = 0777
 force user = deck
 force group = deck
 
+[home]
+comment = Home folder
+path = /home/
+browseable = yes
+read only = no
+create mask = 0777
+directory mask = 0777
+force user = deck
+force group = deck
+
 [downloads]
 comment = Downloads directory
 path = /home/deck/Downloads/


### PR DESCRIPTION
Now users can manually input the directories they want to share, instead of being restricted to sharing only the 'steamapps', 'downloads', and 'mmcblk0p1' folders.

Details:
Users can now input the path of the folder they wish to share via an interactive loop within the script. This loop asks users to enter a directory path, verifies its existence and whether it's a directory, and then adds it to the smb.conf.
After adding each directory, the user is prompted to decide whether they want to add more directories, allowing for sharing multiple directories.

  - Default Directory:
    In default, the script will share the /home/ directory if the user pressed enter without input, this is for the convenience of quick setup.

Example run:
[output.txt](https://github.com/malordin/steamdeck-samba-server/files/15440962/output.txt)
